### PR TITLE
ci: build python 3.12 whls

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        version: [cp38-*, cp39-*, cp310-*, cp311-*]
+        version: [cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Our organization is trying to stay up to date with the latest version of python and it would simplify our build pipeline if readily available whls for python 3.12 were available.